### PR TITLE
Updated AJAX

### DIFF
--- a/jcomponent.js
+++ b/jcomponent.js
@@ -844,7 +844,7 @@ COM.AJAX = function(url, data, callback, timeout, error) {
 	setTimeout(function() {
 
 		if (method === 'GET' && data)
-			url += '?' + (typeof(data) === 'string' ? data : jQuery.param(data));
+			url += '?' + (typeof(data) === 'string' ? data : jQuery.param(data, true));
 
 		var options = {};
 		options.type = method;


### PR DESCRIPTION
A value returned by jQuery.param({arr: ["item1", "item2"]}); --> "arr[]=item1&arr[]=item2" is parsed by node.js's querystring.parse as {arr[]: ["item1", "item2"]} .
Second argument set to true fixes this --> jQuery.param({arr: ["item1", "item2"]}, true); --> "arr=item1&arr=item2" --> node.js querystring.parse --> {arr: ["item1", "item2"]} .
