### PR TITLE
Added `NP.round(decimals)`

### DIFF
--- a/jc.js
+++ b/jc.js
@@ -8173,23 +8173,6 @@
 		return +(Math.round(this + 'e+' + decimals) + 'e-' + decimals);
 	};
 
-	NP.VAT = function(percentage, decimals, includedVAT) {
-		var num = this;
-		var type = typeof(decimals);
-
-		if (type === 'boolean') {
-			var tmp = includedVAT;
-			includedVAT = decimals;
-			decimals = tmp;
-			type = typeof(decimals);
-		}
-
-		if (type === 'undefined')
-			decimals = 2;
-
-		return !percentage || !num ? num.round(decimals) : includedVAT ? (num / ((percentage / 100) + 1)).round(decimals) : (num * ((percentage / 100) + 1)).round(decimals);
-	};
-
 	SP.format = function() {
 		var arg = arguments;
 		return this.replace(M.regexp.format, function(text) {

--- a/jc.js
+++ b/jc.js
@@ -8169,6 +8169,27 @@
 		return new Date(this + (offset || 0));
 	};
 
+	NP.round = function(decimals) {
+		return +(Math.round(this + 'e+' + decimals) + 'e-' + decimals);
+	};
+
+	NP.VAT = function(percentage, decimals, includedVAT) {
+		var num = this;
+		var type = typeof(decimals);
+
+		if (type === 'boolean') {
+			var tmp = includedVAT;
+			includedVAT = decimals;
+			decimals = tmp;
+			type = typeof(decimals);
+		}
+
+		if (type === 'undefined')
+			decimals = 2;
+
+		return !percentage || !num ? num.round(decimals) : includedVAT ? (num / ((percentage / 100) + 1)).round(decimals) : (num * ((percentage / 100) + 1)).round(decimals);
+	};
+
 	SP.format = function() {
 		var arg = arguments;
 		return this.replace(M.regexp.format, function(text) {


### PR DESCRIPTION


I've added Number function `round()` for correct rounding of numbers. Especially for price rounding.
e.g.
8.666.round(2) = 8.67
8.666.round(3) = 8.666

Both functions have been tested.